### PR TITLE
Image-installer: Fix duplication of image prefix

### DIFF
--- a/sonic_installer/bootloader/onie.py
+++ b/sonic_installer/bootloader/onie.py
@@ -21,7 +21,10 @@ class OnieInstallerBootloader(Bootloader): # pylint: disable=abstract-method
         cmdline = open('/proc/cmdline', 'r')
         current = re.search(r"loop=(\S+)/fs.squashfs", cmdline.read()).group(1)
         cmdline.close()
-        return current.replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX)
+        # Replace only the first occurrence, since we are using branch name as
+        # tagging for version, IMAGE_PREFIX in the name of the branch may be
+        # replaced as well.
+        return current.replace(IMAGE_DIR_PREFIX, IMAGE_PREFIX, 1)
 
     def get_binary_image_version(self, image_path):
         """returns the version of the image"""


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
* SONiC prefix shown twice when working branch contains "image-" in its name.
<img width="583" alt="Screenshot 2022-05-18 at 14 08 12" src="https://user-images.githubusercontent.com/35844154/169044815-4ff57d56-8aff-46a6-a0e3-9a54665afcde.png">

#### How I did it
Fixed sonic-installer's one bootloader wrapper to show correct version.
<img width="558" alt="Screenshot 2022-05-18 at 14 08 33" src="https://user-images.githubusercontent.com/35844154/169044849-a1db656c-f1b1-4a5c-ba87-7aafcf8daa5a.png">

#### How to verify it
Build image (the branch is important):
```
cd sonic-buildimage
git checkout -b dev-image-test
make configure PLATFORM=mellanox && make target/sonic-mellanox.bin
```
Run image on the switch and execute:
```
sudo sonic-installer list
```

#### Previous command output (if the output of a command-line utility has changed)
<img width="583" alt="Screenshot 2022-05-18 at 14 08 12" src="https://user-images.githubusercontent.com/35844154/169044815-4ff57d56-8aff-46a6-a0e3-9a54665afcde.png">

#### New command output (if the output of a command-line utility has changed)
<img width="558" alt="Screenshot 2022-05-18 at 14 08 33" src="https://user-images.githubusercontent.com/35844154/169044849-a1db656c-f1b1-4a5c-ba87-7aafcf8daa5a.png">

