### PR TITLE
Implement clock CLI

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1,6 +1,7 @@
 #!/usr/sbin/env python
 
 import click
+import datetime
 import ipaddress
 import json
 import jsonpatch
@@ -7055,6 +7056,68 @@ def del_subinterface(ctx, subinterface_name):
         config_db.set_entry('VLAN_SUB_INTERFACE', subinterface_name, None)
     except JsonPatchConflict as e:
         ctx.fail("{} is invalid vlan subinterface. Error: {}".format(subinterface_name, e))
+
+
+#
+# 'clock' group ('config clock ...')
+#
+@config.group()
+def clock():
+    """Configuring system clock"""
+    pass
+
+
+def get_tzs(ctx, args, incomplete):
+    ret = clicommon.run_command('timedatectl list-timezones',
+                                display_cmd=False, ignore_error=False,
+                                return_cmd=True)
+    if len(ret) == 0:
+        return []
+
+    lst = ret[0].split('\n')
+    lst.append('Etc/UTC')
+    return [k for k in lst if incomplete in k]
+
+
+@clock.command()
+@click.argument('timezone', metavar='<timezone_name>', required=True,
+                autocompletion=get_tzs)
+def timezone(timezone):
+    """Set system timezone"""
+
+    if timezone not in get_tzs(None, None, ''):
+        click.echo(f'Timezone {timezone} does not conform format')
+        sys.exit(1)
+
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry(swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, 'localhost',
+                        {'timezone': timezone})
+
+
+@clock.command()
+@click.argument('date', metavar='<YYYY-MM-DD>', required=True)
+@click.argument('time', metavar='<HH:MM:SS>', required=True)
+def date(date, time):
+    """Set system date and time"""
+    valid = True
+    try:
+        datetime.datetime.strptime(date, '%Y-%m-%d')
+    except ValueError:
+        click.echo(f'Date {date} does not conform format YYYY-MM-DD')
+        valid = False
+
+    try:
+        datetime.datetime.strptime(time, '%H:%M:%S')
+    except ValueError:
+        click.echo(f'Time {time} does not conform format HH:MM:SS')
+        valid = False
+
+    if not valid:
+        sys.exit(1)
+
+    clicommon.run_command(f'timedatectl set-time "{date} {time}"')
+
 
 if __name__ == '__main__':
     config()

--- a/show/main.py
+++ b/show/main.py
@@ -1764,13 +1764,31 @@ def uptime(verbose):
     cmd = "uptime -p"
     run_command(cmd, display_cmd=verbose)
 
-@cli.command()
-@click.option('--verbose', is_flag=True, help="Enable verbose output")
-def clock(verbose):
-    """Show date and time"""
-    cmd ="date"
-    run_command(cmd, display_cmd=verbose)
 
+#
+# 'clock' command group ("show clock ...")
+#
+@cli.group('clock', invoke_without_command=True)
+@click.pass_context
+def clock(ctx):
+    """Show date and time"""
+    # If invoking subcomand, no need to do anything
+    if ctx.invoked_subcommand is not None:
+        return
+
+    run_command('date')
+
+
+@clock.command()
+def timezones():
+    """List of available timezones"""
+    run_command('timedatectl list-timezones')
+    click.echo('Etc/UTC')
+
+
+#
+# 'system-memory' command ("show system-memory")
+#
 @cli.command('system-memory')
 @click.option('--verbose', is_flag=True, help="Enable verbose output")
 def system_memory(verbose):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1935,3 +1935,66 @@ class TestConfigNtp(object):
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")
+
+
+class TestConfigClock(object):
+    timezone_test_val = ['Europe/Kyiv', 'Asia/Israel', 'Etc/UTC']
+
+    @classmethod
+    def setup_class(cls):
+        print('SETUP')
+        import config.main
+        importlib.reload(config.main)
+
+    @patch('config.main.get_tzs', mock.Mock(return_value=timezone_test_val))
+    def test_timezone_good(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['timezone'],
+            ['Etc/UTC'], obj=obj)
+
+        assert result.exit_code == 0
+
+    @patch('config.main.get_tzs', mock.Mock(return_value=timezone_test_val))
+    def test_timezone_bad(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['timezone'],
+            ['Atlantis'], obj=obj)
+
+        assert result.exit_code != 0
+        assert 'Timezone Atlantis does not conform format' in result.output
+
+    @patch('utilities_common.cli.run_command',
+           mock.MagicMock(side_effect=mock_run_command_side_effect))
+    def test_date_good(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['date'],
+            ['2020-10-10', '10:20:30'], obj=obj)
+
+        assert result.exit_code == 0
+
+    @patch('utilities_common.cli.run_command',
+           mock.MagicMock(side_effect=mock_run_command_side_effect))
+    def test_date_bad(self):
+        runner = CliRunner()
+        obj = {'db': Db().cfgdb}
+
+        result = runner.invoke(
+            config.config.commands['clock'].commands['date'],
+            ['20-10-10', '60:70:80'], obj=obj)
+
+        assert result.exit_code != 0
+        assert 'Date 20-10-10 does not conform format' in result.output
+        assert 'Time 60:70:80 does not conform format' in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print('TEARDOWN')

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -116,3 +116,37 @@ def test_show_logging_tmpfs_syslog_1(run_command, cli_arguments, expected):
     runner = CliRunner()
     result = runner.invoke(show.cli.commands["logging"], cli_arguments)
     run_command.assert_called_with(EXPECTED_BASE_COMMAND + expected, display_cmd=False)
+
+
+class TestShowClock(object):
+    @classmethod
+    def setup_class(cls):
+        print('SETUP')
+        os.environ['UTILITIES_UNIT_TESTING'] = '1'
+
+    @patch('show.main.run_command')
+    def test_clock(self, mock_rc):
+        runner = CliRunner()
+
+        result = runner.invoke(show.cli.commands['clock'])
+        print(result.exit_code)
+        print(result.output)
+
+        assert result.exit_code == 0
+        mock_rc.assert_called_once_with('date')
+
+    @patch('show.main.run_command')
+    def test_timezone(self, mock_rc):
+        runner = CliRunner()
+
+        result = runner.invoke(
+            show.cli.commands['clock'].commands['timezones'])
+        print(result.exit_code)
+        print(result.output)
+
+        assert result.exit_code == 0
+        mock_rc.assert_called_once_with('timedatectl list-timezones')
+
+    @classmethod
+    def teardown_class(cls):
+        print('TEARDOWN')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
N/A

#### New command output (if the output of a command-line utility has changed)
```
admin@sonic:~$ show clock
Sat 10 Oct 2020 01:02:20 AM HDT
```
```
admin@sonic:~$ show clock timezones
Africa/Abidjan
Africa/Accra
### More data here ##
Pacific/Wallis
UTC
Etc/UTC
```
```
admin@sonic:~$ sudo config clock timezone Europe/Ki # <TAB><TAB>
Europe/Kiev   Europe/Kirov
admin@sonic:~$ sudo config clock timezone Europe/Kiev
admin@sonic:~$ sudo config clock timezone Europe/Kie
Timezone Europe/Kie does not conform format
```
```
admin@sonic:~$ sudo config clock date 2020-10-11 1:2:4
admin@sonic:~$ sudo config clock date 20-40-50 60:70:80
Date 20-40-50 does not conform format YYYY-MM-DD
Time 60:70:80 does not conform format HH:MM:SS
```
